### PR TITLE
Support multiple index sets in Graylog

### DIFF
--- a/graylog_archiver/cli.py
+++ b/graylog_archiver/cli.py
@@ -1,7 +1,7 @@
 import argparse
 from elasticsearch import Elasticsearch
-from graylog_archiver.graylog_archiver import GraylogArchiver
-from graylog_archiver.config import Config
+from .graylog_archiver import GraylogArchiver
+from .config import Config
 
 
 def parse():

--- a/graylog_archiver/graylog_archiver.py
+++ b/graylog_archiver/graylog_archiver.py
@@ -1,7 +1,7 @@
 import shutil
-from graylog_archiver import logs
-from graylog_archiver.graylog_elasticsearch import GraylogElasticsearch
-from graylog_archiver.utils import compress_directory
+from . import logs
+from .graylog_elasticsearch import GraylogElasticsearch
+from .utils import compress_directory
 
 
 class GraylogArchiver:

--- a/graylog_archiver/utils.py
+++ b/graylog_archiver/utils.py
@@ -1,6 +1,5 @@
 import uuid
 from shutil import make_archive
-import os
 
 
 def random_string():

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# coding=utf-8
 
 from setuptools import setup, find_packages
 

--- a/test/tests.py
+++ b/test/tests.py
@@ -1,5 +1,5 @@
 import unittest
-from graylog_archiver.graylog_elasticsearch import sort_indices
+from graylog_archiver.graylog_elasticsearch import sort_indices, group_and_sort_indices
 
 
 class TestStringMethods(unittest.TestCase):
@@ -9,6 +9,17 @@ class TestStringMethods(unittest.TestCase):
         indices_sorted = sort_indices(indices)
         self.assertEqual(['graylog_36', 'graylog_9'], indices_sorted)
 
+    def test_group_and_sort_indexsets(self):
+        indices = [
+            'graylog_9',
+            'graylog_internal_3',
+            'graylog_internal_5',
+            'graylog_36',
+            'graylog_internal_6'
+        ]
+        indices_grouped = group_and_sort_indices(indices)
+        self.assertEqual(['graylog_36', 'graylog_9'], indices_grouped['graylog'])
+        self.assertEqual(['graylog_internal_6', 'graylog_internal_5', 'graylog_internal_3'], indices_grouped['graylog_internal'])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Currently multiple index sets are not supported. The returned list of indices (by sort_indices) will contain all indices over different index sets resulting arbitrary indices being archived over all index sets present.

The pull request will change the behaviour so, that the indices are first grouped by index set name, and then sorted by the index number, after which all but max_indices of the newest indices are archived from each index set.

Also changed to use relative imports for easier testing and development.